### PR TITLE
Add ability to specify hostname

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,11 @@ logentries_logs:
 
 ```
 
+You may also specify hostname, otherwise `ansible_fqdn` will be used:
+```yml
+logentries_hostname: my.host.com
+```
+
 Dependencies
 ------------
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -46,7 +46,7 @@
   changed_when: false
 
 - name: Register host
-  shell: "le register --force --name={{ ansible_fqdn }} --hostname={{ ansible_fqdn }} --yes --account-key={{ logentries_account_key }}"
+  shell: "le register --force --name={{ logentries_hostname | default(ansible_fqdn) }} --hostname={{ logentries_hostname | default(ansible_fqdn) }} --yes --account-key={{ logentries_account_key }}"
   when: result|failed
 
 - name: Install logentries daemon APT


### PR DESCRIPTION
`ansible_fqdn` is a bit messy thing and may behave unpredictable if DNS isn't configured properly (for example https://github.com/ansible/ansible/issues/9972), so it might be a good idea to let people to specify hostname explicitly.
