### PR TITLE
Ubuntu xenial support

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -21,6 +21,7 @@ galaxy_info:
     - trusty
     - vivid
     - wily
+    - xenial
   - name: Debian
     versions:
     - wheezy

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -41,6 +41,14 @@ Vagrant.configure(2) do |config|
       ansible.playbook = "site.yml"
     end
   end
+  config.vm.define "xenial64" do |xenial64|
+    xenial64.vm.box = "ubuntu/xenial64"
+    xenial64.vm.network :private_network, :ip => "10.1.1.18"
+    xenial64.vm.provision "ansible" do |ansible|
+      ansible.sudo = true
+      ansible.playbook = "site.yml"
+    end
+  end
   config.vm.define "vivid64" do |vivid64|
     vivid64.vm.box = "ubuntu/vivid64"
     vivid64.vm.network :private_network, :ip => "10.1.1.16"

--- a/vagrant/inventory
+++ b/vagrant/inventory
@@ -5,3 +5,4 @@ precise64 ansible_ssh_host=10.1.1.14
 trusty64 ansible_ssh_host=10.1.1.15
 vivid64 ansible_ssh_host=10.1.1.16
 centos ansible_ssh_host=10.1.1.17
+xenial64 ansible_ssh_host=10.1.1.18


### PR DESCRIPTION
Logentries.com added recently support for Ubuntu Xenial (http://rep.logentries.com/dists/xenial/).
