### PR TITLE
Add the possibility to use existing log set...

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,11 @@ You may also specify hostname, otherwise `ansible_fqdn` will be used:
 logentries_hostname: my.host.com
 ```
 
+Alternatively you can specify the key of existing logentries log set:
+```yml
+logentries_set_key: xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+```
+
 Dependencies
 ------------
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,6 +39,10 @@
   with_items: '{{ logentries_packages }}'
   when: ansible_os_family == "Debian"
 
+- name: Ensure logentries config directory exists
+  file: path=/etc/le state=directory group=root owner=root mode=750
+  when: logentries_set_key is defined
+
 - name: Add logentries config
   template: src=config.j2 dest=/etc/le/config mode=640 owner=root group=root
   when: logentries_set_key is defined

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,15 +39,22 @@
   with_items: '{{ logentries_packages }}'
   when: ansible_os_family == "Debian"
 
+- name: Add logentries config
+  template: src=config.j2 dest=/etc/le/config mode=640 owner=root group=root
+  when: logentries_set_key is defined
+  notify:
+  - Restart logentries
+
 - name: Check if host is registered
   command: le whoami
   register: result
   ignore_errors: true
   changed_when: false
+  when: logentries_set_key is not defined
 
 - name: Register host
   shell: "le register --force --name={{ logentries_hostname | default(ansible_fqdn) }} --hostname={{ logentries_hostname | default(ansible_fqdn) }} --yes --account-key={{ logentries_account_key }}"
-  when: result|failed
+  when: result|failed and logentries_set_key is not defined
 
 - name: Install logentries daemon APT
   apt: name={{ logentries_daemon_package }} state=present

--- a/templates/config.j2
+++ b/templates/config.j2
@@ -1,0 +1,3 @@
+[Main]
+user-key={{ logentries_account_key }}
+agent-key={{ logentries_set_key }}


### PR DESCRIPTION
instead of providing `logentries_hostname` you may provide a key for existing
log set via `logentries_set_key`. This can be found in logentries UI as
"Log Set Key".
