### PR TITLE
Add sleep to daemon restart

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,3 @@
 ---
 - name: Restart logentries
-  service: name={{ logentries_service }} state=restarted
+  service: name={{ logentries_service }} state=restarted sleep=5


### PR DESCRIPTION
Add sleep argument to allow LogEntries daemon to restart properly.
This should take care of #18 