### PR TITLE
Add handler for restarting on xenial/systemd

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,8 @@
 ---
 - name: Restart logentries
   service: name={{ logentries_service }} state=restarted sleep=5
+  when: not (ansible_distribution == "Ubuntu" and ansible_distribution_release == "xenial")
+ 
+- name: Restart logentries
+  systemd: name={{ logentries_service }} daemon_reload=yes
+  when: ansible_distribution == "Ubuntu" and ansible_distribution_release == "xenial"


### PR DESCRIPTION
The current handler errors on first run. This change specifically uses
the systemd module for Ubuntu xenial to reload config.